### PR TITLE
Lenient decode + Fix for UTF-8 Text decoding

### DIFF
--- a/base16.cabal
+++ b/base16.cabal
@@ -31,6 +31,7 @@ library
     Data.ByteString.Base16
     Data.ByteString.Lazy.Base16
     Data.Text.Encoding.Base16
+    Data.Text.Encoding.Base16.Error
     Data.Text.Lazy.Encoding.Base16
 
   other-modules:

--- a/benchmarks/Base16Bench.hs
+++ b/benchmarks/Base16Bench.hs
@@ -56,32 +56,32 @@ main =
       [ bgroup "25"
         [ bench "memory" $ whnf cfob bs25
         , bench "base16-bytestring" $ whnf Bos.decode bs25
-        , bench "base16" $ whnf B16.decodeBase16 bs25
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs25
         ]
       , bgroup "100"
         [ bench "memory" $ whnf cfob bs100
         , bench "base16-bytestring" $ whnf Bos.decode bs100
-        , bench "base16" $ whnf B16.decodeBase16 bs100
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs100
         ]
       , bgroup "1k"
         [ bench "memory" $ whnf cfob bs1k
         , bench "base16-bytestring" $ whnf Bos.decode bs1k
-        , bench "base16" $ whnf B16.decodeBase16 bs1k
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs1k
         ]
       , bgroup "10k"
         [ bench "memory" $ whnf cfob bs10k
         , bench "base16-bytestring" $ whnf Bos.decode bs10k
-        , bench "base16" $ whnf B16.decodeBase16 bs10k
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs10k
         ]
       , bgroup "100k"
         [ bench "memory" $ whnf cfob bs100k
         , bench "base16-bytestring" $ whnf Bos.decode bs100k
-        , bench "base16" $ whnf B16.decodeBase16 bs100k
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs100k
         ]
       , bgroup "1mm"
         [ bench "memory" $ whnf cfob bs1mm
         , bench "base16-bytestring" $ whnf Bos.decode bs1mm
-        , bench "base16" $ whnf B16.decodeBase16 bs1mm
+        , bench "base16" $ whnf B16.decodeBase16Lenient bs1mm
         ]
       ]
     ]
@@ -109,3 +109,39 @@ main =
       e <- ctob <$> random 100000
       f <- ctob <$> random 1000000
       return ((a,b,c,d,e,f),(fromStrict a,fromStrict b,fromStrict c,fromStrict d,fromStrict e,fromStrict f))
+
+data MegaFunctor f a where
+  Pure :: a -> MegaFunctor f a
+  Ap :: f a -> MegaFunctor f (a -> b) -> MegaFunctor f b
+  Select :: MegaFunctor f (Either a b) -> f (a -> b) -> MegaFunctor f b
+  Join :: MegaFunctor (MegaFunctor f) a -> MegaFunctor f a
+
+instance Functor f => Functor (MegaFunctor f) where
+  fmap f (Pure a) = Pure (f a)
+  fmap f (Ap x y) = Ap x ((f .) <$> y)
+  fmap f (Select x y) = Select (fmap f <$> x) (fmap f <$> y)
+  fmap f (Bind x y) = Bind x (fmap f <$> y)
+
+instance Functor f => Applicative (MegaFunctor f) where
+  pure = Pure
+  Pure f <*> y = fmap f y
+  Ap x y <*> z = Ap x (flip <$> y <*> z)
+  f@(Select _ _) <*> x = select (Left <$> f) ((&) <$> x)
+  x@(Bind _ _) <*> y = do
+    x1 <- x
+    x1 <$> y
+
+instance Functor f => Selective (MegaFunctor f) where
+  select x (Pure y) = either y id <$> x -- Generalised identity
+  select x y@(Ap _ _) = (\e f -> either f id e) <$> x <*> y
+  select x (Select y z) = Select (select (f <$> x) (g <$> y)) (h <$> z) -- Associativity
+    where
+      f x = Right <$> x
+      g y a = bimap (, a) ($a) y
+      h = uncurry
+  select x y@(Bind _ _) = x >>= \case
+    Left a -> ($a) <$> y
+    Right b -> pure b
+
+instance Functor f => Monad (MegaFunctor f) where
+  return = pure

--- a/benchmarks/Base16Bench.hs
+++ b/benchmarks/Base16Bench.hs
@@ -10,8 +10,8 @@ import Criterion.Main
 import Data.ByteString.Lazy (fromStrict)
 import "memory" Data.ByteArray.Encoding as Mem
 import Data.ByteString
-import "base16" Data.ByteString.Lazy.Base16 as B16
-import "base16-bytestring" Data.ByteString.Base16.Lazy as Bos
+import "base16" Data.ByteString.Base16 as B16
+import "base16-bytestring" Data.ByteString.Base16 as Bos
 import Data.ByteString.Random (random)
 
 
@@ -22,66 +22,66 @@ main =
       bgroup "encode"
       [ bgroup "25"
         [ bench "memory" $ whnf ctob bs25
-        , bench "base16-bytestring" $ whnf Bos.encode bs25L
-        , bench "base16" $ whnf B16.encodeBase16' bs25L
+        , bench "base16-bytestring" $ whnf Bos.encode bs25
+        , bench "base16" $ whnf B16.encodeBase16' bs25
         ]
       , bgroup "100"
         [ bench "memory" $ whnf ctob bs100
-        , bench "base16-bytestring" $ whnf Bos.encode bs100L
-        , bench "base16" $ whnf B16.encodeBase16' bs100L
+        , bench "base16-bytestring" $ whnf Bos.encode bs100
+        , bench "base16" $ whnf B16.encodeBase16' bs100
         ]
       , bgroup "1k"
         [ bench "memory" $ whnf ctob bs1k
-        , bench "base16-bytestring" $ whnf Bos.encode bs1kL
-        , bench "base16" $ whnf B16.encodeBase16' bs1kL
+        , bench "base16-bytestring" $ whnf Bos.encode bs1k
+        , bench "base16" $ whnf B16.encodeBase16' bs1k
         ]
       , bgroup "10k"
         [ bench "memory" $ whnf ctob bs10k
-        , bench "base16-bytestring" $ whnf Bos.encode bs10kL
-        , bench "base16" $ whnf B16.encodeBase16' bs10kL
+        , bench "base16-bytestring" $ whnf Bos.encode bs10k
+        , bench "base16" $ whnf B16.encodeBase16' bs10k
         ]
       , bgroup "100k"
         [ bench "memory" $ whnf ctob bs100k
-        , bench "base16-bytestring" $ whnf Bos.encode bs100kL
-        , bench "base16" $ whnf B16.encodeBase16' bs100kL
+        , bench "base16-bytestring" $ whnf Bos.encode bs100k
+        , bench "base16" $ whnf B16.encodeBase16' bs100k
         ]
       , bgroup "1mm"
         [ bench "memory" $ whnf ctob bs1mm
-        , bench "base16-bytestring" $ whnf Bos.encode bs1mmL
-        , bench "base16" $ whnf B16.encodeBase16' bs1mmL
+        , bench "base16-bytestring" $ whnf Bos.encode bs1mm
+        , bench "base16" $ whnf B16.encodeBase16' bs1mm
         ]
       ]
     , env bs' $ \ ~((bs25,bs100,bs1k,bs10k,bs100k,bs1mm),(bs25L,bs100L,bs1kL,bs10kL,bs100kL,bs1mmL)) ->
       bgroup "decode"
       [ bgroup "25"
         [ bench "memory" $ whnf cfob bs25
-        , bench "base16-bytestring" $ whnf Bos.decode bs25L
-        , bench "base16" $ whnf B16.decodeBase16 bs25L
+        , bench "base16-bytestring" $ whnf Bos.decode bs25
+        , bench "base16" $ whnf B16.decodeBase16 bs25
         ]
       , bgroup "100"
         [ bench "memory" $ whnf cfob bs100
-        , bench "base16-bytestring" $ whnf Bos.decode bs100L
-        , bench "base16" $ whnf B16.decodeBase16 bs100L
+        , bench "base16-bytestring" $ whnf Bos.decode bs100
+        , bench "base16" $ whnf B16.decodeBase16 bs100
         ]
       , bgroup "1k"
         [ bench "memory" $ whnf cfob bs1k
-        , bench "base16-bytestring" $ whnf Bos.decode bs1kL
-        , bench "base16" $ whnf B16.decodeBase16 bs1kL
+        , bench "base16-bytestring" $ whnf Bos.decode bs1k
+        , bench "base16" $ whnf B16.decodeBase16 bs1k
         ]
       , bgroup "10k"
         [ bench "memory" $ whnf cfob bs10k
-        , bench "base16-bytestring" $ whnf Bos.decode bs10kL
-        , bench "base16" $ whnf B16.decodeBase16 bs10kL
+        , bench "base16-bytestring" $ whnf Bos.decode bs10k
+        , bench "base16" $ whnf B16.decodeBase16 bs10k
         ]
       , bgroup "100k"
         [ bench "memory" $ whnf cfob bs100k
-        , bench "base16-bytestring" $ whnf Bos.decode bs100kL
-        , bench "base16" $ whnf B16.decodeBase16 bs100kL
+        , bench "base16-bytestring" $ whnf Bos.decode bs100k
+        , bench "base16" $ whnf B16.decodeBase16 bs100k
         ]
       , bgroup "1mm"
         [ bench "memory" $ whnf cfob bs1mm
-        , bench "base16-bytestring" $ whnf Bos.decode bs1mmL
-        , bench "base16" $ whnf B16.decodeBase16 bs1mmL
+        , bench "base16-bytestring" $ whnf Bos.decode bs1mm
+        , bench "base16" $ whnf B16.decodeBase16 bs1mm
         ]
       ]
     ]

--- a/src/Data/ByteString/Base16.hs
+++ b/src/Data/ByteString/Base16.hs
@@ -18,6 +18,7 @@ module Data.ByteString.Base16
 ( encodeBase16
 , encodeBase16'
 , decodeBase16
+, decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -55,6 +56,15 @@ encodeBase16' = encodeBase16_
 decodeBase16 :: ByteString -> Either Text ByteString
 decodeBase16 = decodeBase16_
 {-# INLINE decodeBase16 #-}
+
+-- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- strategy that never fails
+--
+-- N.B.: this is not RFC 4648-compliant
+--
+decodeBase16Lenient :: ByteString -> ByteString
+decodeBase16Lenient = decodeBase16Lenient_
+{-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a 'ByteString' value is base16 encoded.
 --

--- a/src/Data/ByteString/Base16.hs
+++ b/src/Data/ByteString/Base16.hs
@@ -49,7 +49,7 @@ encodeBase16' :: ByteString -> ByteString
 encodeBase16' = encodeBase16_
 {-# INLINE encodeBase16' #-}
 
--- | Decode a padded Base16-encoded 'ByteString' value.
+-- | Decode a Base16-encoded 'ByteString' value.
 --
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
@@ -57,7 +57,7 @@ decodeBase16 :: ByteString -> Either Text ByteString
 decodeBase16 = decodeBase16_
 {-# INLINE decodeBase16 #-}
 
--- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- | Decode a Base16-encoded 'ByteString' value leniently, using a
 -- strategy that never fails
 --
 -- N.B.: this is not RFC 4648-compliant

--- a/src/Data/ByteString/Base16/Internal/Utils.hs
+++ b/src/Data/ByteString/Base16/Internal/Utils.hs
@@ -65,7 +65,7 @@ reChunk (c:cs) = case B.length c `divMod` 2 of
   where
     cont_ q [] = [q]
     cont_ q (a:as) = case B.splitAt 1 a of
-      ~(x, y) -> let q' = q <> x
+      ~(x, y) -> let q' = B.append q x
         in if B.length q' == 2
           then
             let as' = if B.null y then as else y:as

--- a/src/Data/ByteString/Base16/Internal/W16/Loop.hs
+++ b/src/Data/ByteString/Base16/Internal/W16/Loop.hs
@@ -114,7 +114,7 @@ lenientLoop
 lenientLoop !dfp !hi !lo !dptr !sptr !end !nn = goHi dptr sptr nn
   where
     goHi !dst !src !n
-      | src == end = return (PS dfp 0 (n + 1))
+      | src == end = return (PS dfp 0 n)
       | otherwise = do
         !x <- peek @Word8 src
         !a <- peekByteOff hi (fromIntegral x)

--- a/src/Data/ByteString/Base16/Internal/W16/Loop.hs
+++ b/src/Data/ByteString/Base16/Internal/W16/Loop.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 -- |
@@ -17,6 +18,7 @@
 module Data.ByteString.Base16.Internal.W16.Loop
 ( innerLoop
 , decodeLoop
+, lenientLoop
 ) where
 
 
@@ -71,9 +73,14 @@ decodeLoop
   -> Ptr Word8
   -> Ptr Word8
   -> Ptr Word8
+  -> Int
   -> IO (Either Text ByteString)
-decodeLoop !dfp !hi !lo !dptr !sptr !end = go dptr sptr 0
+decodeLoop !dfp !hi !lo !dptr !sptr !end !nn = go dptr sptr nn
   where
+    err !src = return . Left . T.pack
+      $ "invalid character at offset: "
+      ++ show (src `minusPtr` sptr)
+
     go !dst !src !n
       | src == end = return (Right (PS dfp 0 n))
       | otherwise = do
@@ -83,10 +90,46 @@ decodeLoop !dfp !hi !lo !dptr !sptr !end = go dptr sptr 0
         !a <- peekByteOff hi (fromIntegral x)
         !b <- peekByteOff lo (fromIntegral y)
 
-        if a == 0xff || b == 0xff
-        then return . Left . T.pack
-          $ "invalid character at offset: "
-          ++ show (src `minusPtr` sptr)
-        else do
-          poke dst (a .|. b)
-          go (plusPtr dst 1) (plusPtr src 2) (n + 1)
+        if
+          | a == 0xff -> err src
+          | b == 0xff -> err (plusPtr src 1)
+          | otherwise -> do
+            poke dst (a .|. b)
+            go (plusPtr dst 1) (plusPtr src 2) (n + 1)
+{-# INLINE decodeLoop #-}
+
+-- | Lenient hex decoding loop optimized for 16-bit architectures
+--
+lenientLoop
+  :: ForeignPtr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Int
+  -> IO ByteString
+lenientLoop !dfp !hi !lo !dptr !sptr !end !nn = goHi dptr sptr nn
+  where
+    goHi !dst !src !n
+      | src >= end = return (PS dfp 0 n)
+      | otherwise = do
+        !x <- peek @Word8 src
+        !a <- peekByteOff hi (fromIntegral x)
+
+        if
+          | a == 0xff -> goHi dst (plusPtr src 1) n
+          | otherwise -> goLo dst (plusPtr src 1) a n
+
+    goLo !dst !src !a !n
+      | src >= end = return (PS dfp 0 n)
+      | otherwise = do
+        !y <- peek @Word8 src
+        !b <- peekByteOff lo (fromIntegral y)
+
+        if
+          | b == 0xff -> goLo dst (plusPtr src 1) a n
+          | otherwise -> do
+            poke dst (a .|. b)
+            goHi (plusPtr dst 1) (plusPtr src 1) (n + 1)
+{-# LANGUAGE lenientLoop #-}

--- a/src/Data/ByteString/Base16/Internal/W16/Loop.hs
+++ b/src/Data/ByteString/Base16/Internal/W16/Loop.hs
@@ -98,7 +98,9 @@ decodeLoop !dfp !hi !lo !dptr !sptr !end !nn = go dptr sptr nn
             go (plusPtr dst 1) (plusPtr src 2) (n + 1)
 {-# INLINE decodeLoop #-}
 
--- | Lenient hex decoding loop optimized for 16-bit architectures
+
+-- | Lenient lazy hex decoding loop optimized for 16-bit architectures.
+-- When the 'Right' case is returned, a byte
 --
 lenientLoop
   :: ForeignPtr Word8
@@ -112,7 +114,7 @@ lenientLoop
 lenientLoop !dfp !hi !lo !dptr !sptr !end !nn = goHi dptr sptr nn
   where
     goHi !dst !src !n
-      | src >= end = return (PS dfp 0 n)
+      | src == end = return (PS dfp 0 (n + 1))
       | otherwise = do
         !x <- peek @Word8 src
         !a <- peekByteOff hi (fromIntegral x)
@@ -122,7 +124,7 @@ lenientLoop !dfp !hi !lo !dptr !sptr !end !nn = goHi dptr sptr nn
           | otherwise -> goLo dst (plusPtr src 1) a n
 
     goLo !dst !src !a !n
-      | src >= end = return (PS dfp 0 n)
+      | src == end = return (PS dfp 0 n)
       | otherwise = do
         !y <- peek @Word8 src
         !b <- peekByteOff lo (fromIntegral y)

--- a/src/Data/ByteString/Base16/Internal/W64/Loop.hs
+++ b/src/Data/ByteString/Base16/Internal/W64/Loop.hs
@@ -17,12 +17,14 @@
 module Data.ByteString.Base16.Internal.W64.Loop
 ( innerLoop
 , decodeLoop
+, lenientLoop
 ) where
 
 
 import Data.Bits
 import Data.ByteString.Internal
 import Data.ByteString.Base16.Internal.Utils
+import qualified Data.ByteString.Base16.Internal.W32.Loop as W32
 import Data.Text (Text)
 import qualified Data.Text as T
 
@@ -47,48 +49,9 @@ innerLoop !dptr !sptr !end = go dptr sptr
 
     !alphabet = "0123456789abcdef"#
 
-    tailRound16 !dst !src
-      | src == end = return ()
-      | otherwise = do
-        !t <- peek @Word8 src
-
-        let !a = fromIntegral (lix (unsafeShiftR t 4))
-            !b = fromIntegral (lix t)
-
-        let !w = a .|. (unsafeShiftL b 8)
-
-        poke @Word16 dst w
-
-        tailRound16 (plusPtr dst 2) (plusPtr src 1)
-
-    tailRound32 !dst !src
-      | plusPtr src 3 >= end = tailRound16 (castPtr dst) (castPtr src)
-      | otherwise = do
-#ifdef WORDS_BIGENDIAN
-        !t <- peek src
-#else
-        !t <- byteSwap16 <$> peek @Word16 src
-#endif
-        let !a = unsafeShiftR t 12
-            !b = unsafeShiftR t 8
-            !c = unsafeShiftR t 4
-
-        let !w = w32 (lix a)
-            !x = w32 (lix b)
-            !y = w32 (lix c)
-            !z = w32 (lix t)
-
-        let !xx = w
-              .|. (unsafeShiftL x 8)
-              .|. (unsafeShiftL y 16)
-              .|. (unsafeShiftL z 24)
-
-        poke @Word32 dst xx
-
-        tailRound32 (plusPtr dst 4) (plusPtr src 2)
-
     go !dst !src
-      | plusPtr src 7 >= end = tailRound32 (castPtr dst) (castPtr src)
+      | plusPtr src 7 >= end =
+        W32.innerLoop (castPtr dst) (castPtr src) end
       | otherwise = do
 #ifdef WORDS_BIGENDIAN
         !t <- peek src
@@ -139,61 +102,17 @@ decodeLoop
   -> Ptr Word32
   -> Ptr Word64
   -> Ptr Word8
+  -> Int
   -> IO (Either Text ByteString)
-decodeLoop !dfp !hi !lo !dptr !sptr !end = go dptr sptr 0
+decodeLoop !dfp !hi !lo !dptr !sptr !end !nn = go dptr sptr nn
   where
     err !src = return . Left . T.pack
       $ "invalid character at offset: "
       ++ show (src `minusPtr` sptr)
 
-    tailRound16 !dst !src !n
-      | src == end = return (Right (PS dfp 0 n))
-      | otherwise = do
-        !x <- peek @Word8 src
-        !y <- peek @Word8 (plusPtr src 1)
-
-        !a <- peekByteOff @Word8 hi (fromIntegral x)
-        !b <- peekByteOff @Word8 lo (fromIntegral y)
-
-        if
-          | a == 0xff -> err src
-          | b == 0xff -> err (plusPtr src 1)
-          | otherwise -> do
-            poke dst (a .|. b)
-            return (Right (PS dfp 0 (n + 1)))
-
-    tailRound32 !dst !src !n
-      | plusPtr src 3 >= end = tailRound16 (castPtr dst) (castPtr src) n
-      | otherwise = do
-#ifdef WORDS_BIGENDIAN
-        !t <- peek @Word32 src
-#else
-        !t <- byteSwap32 <$> peek @Word32 src
-#endif
-        let !w = fromIntegral ((unsafeShiftR t 24) .&. 0xff)
-            !x = fromIntegral ((unsafeShiftR t 16) .&. 0xff)
-            !y = fromIntegral ((unsafeShiftR t 8) .&. 0xff)
-            !z = (fromIntegral (t .&. 0xff))
-
-        !a <- peekByteOff @Word8 hi w
-        !b <- peekByteOff @Word8 lo x
-        !c <- peekByteOff @Word8 hi y
-        !d <- peekByteOff @Word8 lo z
-
-        let !zz = fromIntegral (a .|. b)
-               .|. (unsafeShiftL (fromIntegral (c .|. d)) 8)
-
-        if
-          | a == 0xff -> err src
-          | b == 0xff -> err (plusPtr src 1)
-          | c == 0xff -> err (plusPtr src 2)
-          | d == 0xff -> err (plusPtr src 3)
-          | otherwise -> do
-            poke @Word16 dst zz
-            tailRound16 (plusPtr dst 2) (plusPtr src 4) (n + 2)
-
     go !dst !src !n
-      | plusPtr src 7 >= end = tailRound32 (castPtr dst) (castPtr src) n
+      | plusPtr src 7 >= end =
+        W32.decodeLoop dfp hi lo (castPtr dst) (castPtr src) end n
       | otherwise = do
 #ifdef WORDS_BIGENDIAN
         !tt <- peek @Word64 src
@@ -236,3 +155,15 @@ decodeLoop !dfp !hi !lo !dptr !sptr !end = go dptr sptr 0
             poke @Word32 dst zz
             go (plusPtr dst 4) (plusPtr src 8) (n + 4)
 {-# INLINE decodeLoop #-}
+
+lenientLoop
+  :: ForeignPtr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Ptr Word8
+  -> Int
+  -> IO ByteString
+lenientLoop !dfp !hi !lo !dptr !sptr !end !nn =
+  W32.lenientLoop dfp hi lo dptr sptr end nn

--- a/src/Data/ByteString/Lazy/Base16.hs
+++ b/src/Data/ByteString/Lazy/Base16.hs
@@ -59,7 +59,7 @@ decodeBase16 Empty = Right Empty
 decodeBase16 (Chunk b bs) = Chunk <$> B16.decodeBase16_ b <*> decodeBase16 bs
 {-# INLINE decodeBase16 #-}
 
--- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- | Decode a Base16-encoded 'ByteString' value leniently, using a
 -- strategy that never fails
 --
 -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!

--- a/src/Data/ByteString/Lazy/Base16.hs
+++ b/src/Data/ByteString/Lazy/Base16.hs
@@ -16,7 +16,7 @@ module Data.ByteString.Lazy.Base16
 ( encodeBase16
 , encodeBase16'
 , decodeBase16
-, decodeBase16Lenient
+-- , decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -27,6 +27,7 @@ import Prelude hiding (all, elem)
 import Data.ByteString.Lazy (all, elem)
 import Data.ByteString.Lazy.Internal (ByteString(..))
 import qualified Data.ByteString.Base16.Internal.Head as B16
+-- import Data.ByteString.Base16.Internal.Utils (reChunk)
 import Data.Either
 import qualified Data.Text as T
 import Data.Text.Lazy (Text)
@@ -59,15 +60,14 @@ decodeBase16 Empty = Right Empty
 decodeBase16 (Chunk b bs) = Chunk <$> B16.decodeBase16_ b <*> decodeBase16 bs
 {-# INLINE decodeBase16 #-}
 
--- | Decode a Base16-encoded 'ByteString' value leniently, using a
--- strategy that never fails
---
--- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
---
-decodeBase16Lenient :: ByteString -> ByteString
-decodeBase16Lenient Empty = Empty
-decodeBase16Lenient (Chunk b bs) = Chunk (B16.decodeBase16Lenient_ b) (decodeBase16Lenient bs)
-{-# INLINE decodeBase16Lenient #-}
+-- -- | Decode a Base16-encoded 'ByteString' value leniently, using a
+-- -- strategy that never fails
+-- --
+-- -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+-- --
+-- decodeBase16Lenient :: ByteString -> ByteString
+-- decodeBase16Lenient = fromChunks . fmap B16.decodeBase16Lenient_ . reChunk . toChunks
+-- {-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a lazy 'ByteString' value is base16 encoded.
 --

--- a/src/Data/ByteString/Lazy/Base16.hs
+++ b/src/Data/ByteString/Lazy/Base16.hs
@@ -16,7 +16,7 @@ module Data.ByteString.Lazy.Base16
 ( encodeBase16
 , encodeBase16'
 , decodeBase16
--- , decodeBase16Lenient
+, decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -24,10 +24,11 @@ module Data.ByteString.Lazy.Base16
 
 import Prelude hiding (all, elem)
 
-import Data.ByteString.Lazy (all, elem)
+import qualified Data.ByteString as B
+import Data.ByteString.Lazy (all, elem, fromChunks, toChunks)
 import Data.ByteString.Lazy.Internal (ByteString(..))
 import qualified Data.ByteString.Base16.Internal.Head as B16
--- import Data.ByteString.Base16.Internal.Utils (reChunk)
+import Data.ByteString.Base16.Internal.Utils (reChunk)
 import Data.Either
 import qualified Data.Text as T
 import Data.Text.Lazy (Text)
@@ -60,14 +61,18 @@ decodeBase16 Empty = Right Empty
 decodeBase16 (Chunk b bs) = Chunk <$> B16.decodeBase16_ b <*> decodeBase16 bs
 {-# INLINE decodeBase16 #-}
 
--- -- | Decode a Base16-encoded 'ByteString' value leniently, using a
--- -- strategy that never fails
--- --
--- -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
--- --
--- decodeBase16Lenient :: ByteString -> ByteString
--- decodeBase16Lenient = fromChunks . fmap B16.decodeBase16Lenient_ . reChunk . toChunks
--- {-# INLINE decodeBase16Lenient #-}
+-- | Decode a Base16-encoded 'ByteString' value leniently, using a
+-- strategy that never fails
+--
+-- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+--
+decodeBase16Lenient :: ByteString -> ByteString
+decodeBase16Lenient = fromChunks
+  . fmap B16.decodeBase16Lenient_
+  . reChunk
+  . fmap (B.filter (flip elem "0123456789abcdef"))
+  . toChunks
+{-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a lazy 'ByteString' value is base16 encoded.
 --

--- a/src/Data/ByteString/Lazy/Base16.hs
+++ b/src/Data/ByteString/Lazy/Base16.hs
@@ -16,6 +16,7 @@ module Data.ByteString.Lazy.Base16
 ( encodeBase16
 , encodeBase16'
 , decodeBase16
+, decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -57,6 +58,16 @@ decodeBase16 :: ByteString -> Either T.Text ByteString
 decodeBase16 Empty = Right Empty
 decodeBase16 (Chunk b bs) = Chunk <$> B16.decodeBase16_ b <*> decodeBase16 bs
 {-# INLINE decodeBase16 #-}
+
+-- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- strategy that never fails
+--
+-- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+--
+decodeBase16Lenient :: ByteString -> ByteString
+decodeBase16Lenient Empty = Empty
+decodeBase16Lenient (Chunk b bs) = Chunk (B16.decodeBase16Lenient_ b) (decodeBase16Lenient bs)
+{-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a lazy 'ByteString' value is base16 encoded.
 --

--- a/src/Data/Text/Encoding/Base16.hs
+++ b/src/Data/Text/Encoding/Base16.hs
@@ -21,6 +21,7 @@ module Data.Text.Encoding.Base16
 ) where
 
 
+import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import Data.Text (Text)
@@ -36,8 +37,7 @@ encodeBase16 :: Text -> Text
 encodeBase16 = B16.encodeBase16 . T.encodeUtf8
 {-# INLINE encodeBase16 #-}
 
--- | Decode a padded Base16-encoded lazy 'Text' value, catching unicode
--- exceptions if thrown in the decoding process.
+-- | Decode a Base16-encoded lazy 'Text' value.
 --
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
@@ -60,7 +60,7 @@ decodeBase16With t f = case B16.decodeBase16 $ T.encodeUtf8 t of
   Right a -> first ConversionError (f a)
 {-# INLINE decodeBase16With #-}
 
--- | Decode a padded Base16-encoded lazy 'Text' value leniently, using a
+-- | Decode a Base16-encoded lazy 'Text' value leniently, using a
 -- strategy that never fails, catching unicode exceptions raised in the
 -- process of converting to text values.
 --

--- a/src/Data/Text/Encoding/Base16.hs
+++ b/src/Data/Text/Encoding/Base16.hs
@@ -14,6 +14,7 @@
 module Data.Text.Encoding.Base16
 ( encodeBase16
 , decodeBase16
+, decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -39,6 +40,15 @@ encodeBase16 = B16.encodeBase16 . T.encodeUtf8
 decodeBase16 :: Text -> Either Text Text
 decodeBase16 = fmap T.decodeUtf8 . B16.decodeBase16 . T.encodeUtf8
 {-# INLINE decodeBase16 #-}
+
+-- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- strategy that never fails
+--
+-- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+--
+decodeBase16Lenient :: Text -> Text
+decodeBase16Lenient = T.decodeUtf8 . B16.decodeBase16Lenient . T.encodeUtf8
+{-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a 'Text' value is Base16-encoded.
 --

--- a/src/Data/Text/Encoding/Base16.hs
+++ b/src/Data/Text/Encoding/Base16.hs
@@ -41,7 +41,7 @@ decodeBase16 :: Text -> Either Text Text
 decodeBase16 = fmap T.decodeUtf8 . B16.decodeBase16 . T.encodeUtf8
 {-# INLINE decodeBase16 #-}
 
--- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- | Decode a padded Base16-encoded 'Text' value leniently, using a
 -- strategy that never fails
 --
 -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!

--- a/src/Data/Text/Encoding/Base16.hs
+++ b/src/Data/Text/Encoding/Base16.hs
@@ -53,11 +53,11 @@ decodeBase16 = fmap T.decodeLatin1 . B16.decodeBase16 . T.encodeUtf8
 --
 decodeBase16With
     :: Text
-    -> (ByteString -> Either (Base16Error e) Text)
-    -> Either (Base16Error e) Text
+    -> (ByteString -> Either err Text)
+    -> Either (Base16Error err) Text
 decodeBase16With t f = case B16.decodeBase16 $ T.encodeUtf8 t of
   Left de -> Left $ DecodeError de
-  Right a -> f a
+  Right a -> first ConversionError (f a)
 {-# INLINE decodeBase16With #-}
 
 -- | Decode a padded Base16-encoded lazy 'Text' value leniently, using a

--- a/src/Data/Text/Encoding/Base16.hs
+++ b/src/Data/Text/Encoding/Base16.hs
@@ -48,14 +48,21 @@ decodeBase16 = fmap T.decodeLatin1 . B16.decodeBase16 . T.encodeUtf8
 -- | Attempt to decode a lazy 'Text' value as Base16, converting from
 -- 'ByteString' to 'Text' according to some encoding function. In practice,
 -- This is something like 'decodeUtf8'', which may produce an error.
-
+--
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
+-- Example:
+--
+-- @
+-- 'decodeBase16With' 'T.decodeUtf8''
+--   :: 'Text' -> 'Either' ('Base16Error' 'UnicodeException') 'Text'
+-- @
+--
 decodeBase16With
-    :: Text
-    -> (ByteString -> Either err Text)
+    :: (ByteString -> Either err Text)
+    -> Text
     -> Either (Base16Error err) Text
-decodeBase16With t f = case B16.decodeBase16 $ T.encodeUtf8 t of
+decodeBase16With f t = case B16.decodeBase16 $ T.encodeUtf8 t of
   Left de -> Left $ DecodeError de
   Right a -> first ConversionError (f a)
 {-# INLINE decodeBase16With #-}

--- a/src/Data/Text/Encoding/Base16/Error.hs
+++ b/src/Data/Text/Encoding/Base16/Error.hs
@@ -1,0 +1,34 @@
+-- |
+-- Module       : Data.Text.Encoding.Base16.Error
+-- Copyright 	: (c) 2019 Emily Pillmore
+-- License	: BSD-style
+--
+-- Maintainer	: Emily Pillmore <emilypi@cohomolo.gy>
+-- Stability	: Experimental
+-- Portability	: portable
+--
+-- This module contains the error types raised (not as exceptions!)
+-- in the decoding process.
+--
+module Data.Text.Encoding.Base16.Error
+( Base16Error(..)
+) where
+
+
+import Data.Text (Text)
+import Data.Text.Encoding.Error (UnicodeException)
+
+-- | This data type represents the type of decoding errors of
+-- various kinds as they pertain to decoding 'Text' values.
+-- Namely, to distinguish between decoding errors from opaque
+-- unicode exceptions caught in the unicode decoding process.
+--
+data Base16Error
+  = DecodeError Text
+    -- ^ The error associated with decoding failure
+    -- as a result of the Base16 decoding process
+  | UnicodeError UnicodeException
+    -- ^ The error associated with the decoding failure
+    -- as a result of the unicode 'Text' decoding process
+    -- (i.e. 'decodeUtf8')
+  deriving (Eq, Show)

--- a/src/Data/Text/Encoding/Base16/Error.hs
+++ b/src/Data/Text/Encoding/Base16/Error.hs
@@ -16,7 +16,6 @@ module Data.Text.Encoding.Base16.Error
 
 
 import Data.Text (Text)
-import Data.Text.Encoding.Error (UnicodeException)
 
 -- | This data type represents the type of decoding errors of
 -- various kinds as they pertain to decoding 'Text' values.

--- a/src/Data/Text/Encoding/Base16/Error.hs
+++ b/src/Data/Text/Encoding/Base16/Error.hs
@@ -23,12 +23,11 @@ import Data.Text.Encoding.Error (UnicodeException)
 -- Namely, to distinguish between decoding errors from opaque
 -- unicode exceptions caught in the unicode decoding process.
 --
-data Base16Error
+data Base16Error e
   = DecodeError Text
     -- ^ The error associated with decoding failure
     -- as a result of the Base16 decoding process
-  | UnicodeError UnicodeException
+  | CharSetError e
     -- ^ The error associated with the decoding failure
-    -- as a result of the unicode 'Text' decoding process
-    -- (i.e. 'decodeUtf8')
+    -- as a result of the conversion process 'Text' -> charset
   deriving (Eq, Show)

--- a/src/Data/Text/Encoding/Base16/Error.hs
+++ b/src/Data/Text/Encoding/Base16/Error.hs
@@ -27,7 +27,7 @@ data Base16Error e
   = DecodeError Text
     -- ^ The error associated with decoding failure
     -- as a result of the Base16 decoding process
-  | CharSetError e
+  | ConversionError e
     -- ^ The error associated with the decoding failure
-    -- as a result of the conversion process 'Text' -> charset
+    -- as a result of the conversion process `'ByteString' -> 'Text'
   deriving (Eq, Show)

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -14,6 +14,7 @@
 module Data.Text.Lazy.Encoding.Base16
 ( encodeBase16
 , decodeBase16
+, decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -40,6 +41,15 @@ encodeBase16 = B16L.encodeBase16 . TL.encodeUtf8
 decodeBase16 :: Text -> Either T.Text Text
 decodeBase16 = fmap TL.decodeUtf8 . B16L.decodeBase16 . TL.encodeUtf8
 {-# INLINE decodeBase16 #-}
+
+-- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- strategy that never fails
+--
+-- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+--
+decodeBase16Lenient :: Text -> Text
+decodeBase16Lenient = TL.decodeUtf8 . B16L.decodeBase16Lenient . TL.encodeUtf8
+{-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a lazy 'Text' value is Base16-encoded.
 --

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -20,9 +20,9 @@ module Data.Text.Lazy.Encoding.Base16
 ) where
 
 
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy.Base16 as B16L
-
-import qualified Data.Text as T
+import Data.Text.Encoding.Base16.Error (Base16Error(..))
 import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy.Encoding as TL
 
@@ -34,22 +34,38 @@ encodeBase16 :: Text -> Text
 encodeBase16 = B16L.encodeBase16 . TL.encodeUtf8
 {-# INLINE encodeBase16 #-}
 
--- | Decode a padded Base16-encoded lazy 'Text' value
+-- | Decode a padded Base16-encoded lazy 'Text' value.
+--
+-- /Warning/: in the conversion to unicode text, exceptions may be thrown.
+-- Please use 'decodeBase16'' if you are unsure if you are working with
+-- true base16-encoded values, or if you expect garbage.
 --
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
-decodeBase16 :: Text -> Either T.Text Text
-decodeBase16 = fmap TL.decodeUtf8 . B16L.decodeBase16 . TL.encodeUtf8
+decodeBase16 :: Text -> Either Base16Error Text
+decodeBase16 t = case B16L.decodeBase16 (TL.encodeUtf8 t) of
+  Left e -> Left (DecodeError e)
+  Right a -> case TL.decodeUtf8' a of
+    Left e' -> Left (UnicodeError e')
+    Right b -> Right b
 {-# INLINE decodeBase16 #-}
 
 -- | Decode a padded Base16-encoded lazy 'Text' value leniently, using a
--- strategy that never fails
+-- strategy that never fails.
+--
+-- /Warning/: in the conversion to unicode text, exceptions may be thrown.
+-- Please use 'decodeBase16Lenient'' if you are unsure if you are working
+-- with true base16-encoded values, or if you expect garbage.
 --
 -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
 --
-decodeBase16Lenient :: Text -> Text
-decodeBase16Lenient = TL.decodeUtf8 . B16L.decodeBase16Lenient . TL.encodeUtf8
+decodeBase16Lenient :: Text -> Either Base16Error Text
+decodeBase16Lenient = first UnicodeError
+  . TL.decodeUtf8'
+  . B16L.decodeBase16Lenient
+  . TL.encodeUtf8
 {-# INLINE decodeBase16Lenient #-}
+
 
 -- | Tell whether a lazy 'Text' value is Base16-encoded.
 --

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -21,6 +21,7 @@ module Data.Text.Lazy.Encoding.Base16
 ) where
 
 
+import Data.Bifunctor (first)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Base16 as B16L
 
@@ -53,11 +54,11 @@ decodeBase16 = fmap TL.decodeLatin1 . B16L.decodeBase16 . TL.encodeUtf8
 --
 decodeBase16With
     :: Text
-    -> (ByteString -> Either (Base16Error e) Text)
-    -> Either (Base16Error e) Text
+    -> (ByteString -> Either err Text)
+    -> Either (Base16Error err) Text
 decodeBase16With t f = case B16L.decodeBase16 $ TL.encodeUtf8 t of
   Left de -> Left $ DecodeError de
-  Right a -> f a
+  Right a -> first ConversionError (f a)
 {-# INLINE decodeBase16With #-}
 
 -- | Decode a Base16-encoded lazy 'Text' value leniently, using a

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -14,14 +14,17 @@
 module Data.Text.Lazy.Encoding.Base16
 ( encodeBase16
 , decodeBase16
+, decodeBase16With
 , decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
 
 
-import Data.Bifunctor (first)
+import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Base16 as B16L
+
+import qualified Data.Text as T
 import Data.Text.Encoding.Base16.Error (Base16Error(..))
 import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy.Encoding as TL
@@ -34,38 +37,41 @@ encodeBase16 :: Text -> Text
 encodeBase16 = B16L.encodeBase16 . TL.encodeUtf8
 {-# INLINE encodeBase16 #-}
 
--- | Decode a padded Base16-encoded lazy 'Text' value.
---
--- /Warning/: in the conversion to unicode text, exceptions may be thrown.
--- Please use 'decodeBase16'' if you are unsure if you are working with
--- true base16-encoded values, or if you expect garbage.
+-- | Decode a Base16-encoded lazy 'Text' value.
 --
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
-decodeBase16 :: Text -> Either Base16Error Text
-decodeBase16 t = case B16L.decodeBase16 (TL.encodeUtf8 t) of
-  Left e -> Left (DecodeError e)
-  Right a -> case TL.decodeUtf8' a of
-    Left e' -> Left (UnicodeError e')
-    Right b -> Right b
+decodeBase16 :: Text -> Either T.Text Text
+decodeBase16 = fmap TL.decodeLatin1 . B16L.decodeBase16 . TL.encodeUtf8
 {-# INLINE decodeBase16 #-}
 
--- | Decode a padded Base16-encoded lazy 'Text' value leniently, using a
+-- | Attempt to decode a lazy 'Text' value as Base16, converting from
+-- 'ByteString' to 'Text' according to some encoding function. In practice,
+-- This is something like 'decodeUtf8'', which may produce an error.
+
+-- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
+--
+decodeBase16With
+    :: Text
+    -> (ByteString -> Either (Base16Error e) Text)
+    -> Either (Base16Error e) Text
+decodeBase16With t f = case B16L.decodeBase16 $ TL.encodeUtf8 t of
+  Left de -> Left $ DecodeError de
+  Right a -> f a
+{-# INLINE decodeBase16With #-}
+
+-- | Decode a Base16-encoded lazy 'Text' value leniently, using a
 -- strategy that never fails.
 --
 -- /Warning/: in the conversion to unicode text, exceptions may be thrown.
--- Please use 'decodeBase16Lenient'' if you are unsure if you are working
--- with true base16-encoded values, or if you expect garbage.
+-- Please use 'decodeBase16'' if you are unsure if you are working with
+-- base16-encoded values, or if you expect garbage.
 --
 -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
 --
-decodeBase16Lenient :: Text -> Either Base16Error Text
-decodeBase16Lenient = first UnicodeError
-  . TL.decodeUtf8'
-  . B16L.decodeBase16Lenient
-  . TL.encodeUtf8
+decodeBase16Lenient :: Text -> Text
+decodeBase16Lenient = TL.decodeLatin1 . B16L.decodeBase16Lenient . TL.encodeUtf8
 {-# INLINE decodeBase16Lenient #-}
-
 
 -- | Tell whether a lazy 'Text' value is Base16-encoded.
 --

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -42,7 +42,7 @@ decodeBase16 :: Text -> Either T.Text Text
 decodeBase16 = fmap TL.decodeUtf8 . B16L.decodeBase16 . TL.encodeUtf8
 {-# INLINE decodeBase16 #-}
 
--- | Decode a padded Base16-encoded 'ByteString' value leniently, using a
+-- | Decode a padded Base16-encoded lazy 'Text' value leniently, using a
 -- strategy that never fails
 --
 -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!

--- a/src/Data/Text/Lazy/Encoding/Base16.hs
+++ b/src/Data/Text/Lazy/Encoding/Base16.hs
@@ -15,7 +15,7 @@ module Data.Text.Lazy.Encoding.Base16
 ( encodeBase16
 , decodeBase16
 , decodeBase16With
-, decodeBase16Lenient
+-- , decodeBase16Lenient
 , isBase16
 , isValidBase16
 ) where
@@ -49,30 +49,37 @@ decodeBase16 = fmap TL.decodeLatin1 . B16L.decodeBase16 . TL.encodeUtf8
 -- | Attempt to decode a lazy 'Text' value as Base16, converting from
 -- 'ByteString' to 'Text' according to some encoding function. In practice,
 -- This is something like 'decodeUtf8'', which may produce an error.
-
+--
 -- See: <https://tools.ietf.org/html/rfc4648#section-8 RFC-4648 section 8>
 --
+-- Example:
+--
+-- @
+-- 'decodeBase16With' 'T.decodeUtf8''
+--   :: 'Text' -> 'Either' ('Base16Error' 'UnicodeException') 'Text'
+-- @
+--
 decodeBase16With
-    :: Text
-    -> (ByteString -> Either err Text)
+    :: (ByteString -> Either err Text)
+    -> Text
     -> Either (Base16Error err) Text
-decodeBase16With t f = case B16L.decodeBase16 $ TL.encodeUtf8 t of
+decodeBase16With f t = case B16L.decodeBase16 $ TL.encodeUtf8 t of
   Left de -> Left $ DecodeError de
   Right a -> first ConversionError (f a)
 {-# INLINE decodeBase16With #-}
 
--- | Decode a Base16-encoded lazy 'Text' value leniently, using a
--- strategy that never fails.
---
--- /Warning/: in the conversion to unicode text, exceptions may be thrown.
--- Please use 'decodeBase16'' if you are unsure if you are working with
--- base16-encoded values, or if you expect garbage.
---
--- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
---
-decodeBase16Lenient :: Text -> Text
-decodeBase16Lenient = TL.decodeLatin1 . B16L.decodeBase16Lenient . TL.encodeUtf8
-{-# INLINE decodeBase16Lenient #-}
+-- -- | Decode a Base16-encoded lazy 'Text' value leniently, using a
+-- -- strategy that never fails.
+-- --
+-- -- /Warning/: in the conversion to unicode text, exceptions may be thrown.
+-- -- Please use 'decodeBase16'' if you are unsure if you are working with
+-- -- base16-encoded values, or if you expect garbage.
+-- --
+-- -- N.B.: this is not RFC 4648-compliant. It may give you garbage if you're not careful!
+-- --
+-- decodeBase16Lenient :: Text -> Text
+-- decodeBase16Lenient = TL.decodeLatin1 . B16L.decodeBase16Lenient . TL.encodeUtf8
+-- {-# INLINE decodeBase16Lenient #-}
 
 -- | Tell whether a lazy 'Text' value is Base16-encoded.
 --

--- a/test/Base16Tests.hs
+++ b/test/Base16Tests.hs
@@ -31,7 +31,7 @@ tests = testGroup "Base16 Tests"
     [ testVectors
     , sanityTests
     , alphabetTests
- --   , lenientTests
+    , lenientTests
     ]
 
 testVectors :: TestTree
@@ -159,6 +159,9 @@ alphabetTests = testGroup "Alphabet tests"
       , conforms 4
       , conforms 5
       , conforms 6
+      , conforms 32
+      , conforms 33
+      , conforms 1001
       ]
     , testGroup "Lazy"
       [ conformsL 0
@@ -167,6 +170,7 @@ alphabetTests = testGroup "Alphabet tests"
       , conformsL 6
       , conformsL 32
       , conformsL 33
+      , conformsL 1001
       ]
     ]
   where
@@ -182,40 +186,40 @@ alphabetTests = testGroup "Alphabet tests"
       assertBool ("failed validity: " ++ show b) $ B16L.isValidBase16 b
       assertBool ("failed correctness: " ++ show b) $ B16L.isBase16 b
 
--- lenientTests :: TestTree
--- lenientTests = testGroup "Lenient Tests"
---     [ testGroup "strict encode/lenient decode"
---       [ testCaseB16 "" ""
---       , testCaseB16 "f" "6+6"
---       , testCaseB16 "fo" "6$6+6|f"
---       , testCaseB16 "foo" "==========6$$66()*f6f"
---       , testCaseB16 "foob" "66^%$&^6f6f62"
---       , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
---       , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
---       ]
---     , testGroup "lazy encode/decode"
---       [ testCaseB16L "" ""
---       , testCaseB16L "f" "6+++++++____++++++======*%$@#%#^*$^6"
---       , testCaseB16L "fo" "6$6+6|f"
---       , testCaseB16L "foo" "==========6$$66()*f6f"
---       , testCaseB16L "foob" "66^%$&^6f6f62"
---       , testCaseB16L "fooba" "666f()*#@6f#)(@*)6()*)2()61"
---       , testCaseB16L "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
---       ]
---     ]
---   where
---     testCaseB16 s t =
---       testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
---         let t0 = B16.decodeBase16 (B16.encodeBase16' s)
---             t1 = B16.decodeBase16Lenient t
+lenientTests :: TestTree
+lenientTests = testGroup "Lenient Tests"
+    [ testGroup "strict encode/lenient decode"
+      [ testCaseB16 "" ""
+      , testCaseB16 "f" "6+6"
+      , testCaseB16 "fo" "6$6+6|f"
+      , testCaseB16 "foo" "==========6$$66()*f6f"
+      , testCaseB16 "foob" "66^%$&^6f6f62"
+      , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+      , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+      ]
+    , testGroup "lazy encode/decode"
+      [ testCaseB16L "" ""
+      , testCaseB16L "f" "6+++++++____++++++======*%$@#%#^*$^6"
+      , testCaseB16L "fo" "6$6+6|f"
+      , testCaseB16L "foo" "==========6$$66()*f6f"
+      , testCaseB16L "foob" "66^%$&^6f6f62"
+      , testCaseB16L "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+      , testCaseB16L "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+      ]
+    ]
+  where
+    testCaseB16 s t =
+      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+        let t0 = B16.decodeBase16 (B16.encodeBase16' s)
+            t1 = B16.decodeBase16Lenient t
 
---         step "compare decoding"
---         t0 @=? Right t1
+        step "compare decoding"
+        t0 @=? Right t1
 
---     testCaseB16L s t =
---       testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
---         let t0 = fmap toStrict $ B16L.decodeBase16 (B16L.encodeBase16' s)
---             t1 = Right . toStrict $ B16L.decodeBase16Lenient t
+    testCaseB16L s t =
+      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+        let t0 = fmap toStrict $ B16L.decodeBase16 (B16L.encodeBase16' s)
+            t1 = Right . toStrict $ B16L.decodeBase16Lenient t
 
---         step "compare decoding"
---         t0 @=? t1
+        step "compare decoding"
+        t0 @=? t1

--- a/test/Base16Tests.hs
+++ b/test/Base16Tests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeApplications #-}
@@ -9,7 +10,7 @@ module Main
 
 import Data.Bifunctor
 import Data.ByteString (ByteString)
-import Data.ByteString.Lazy (fromStrict)
+import Data.ByteString.Lazy (fromStrict, toStrict)
 import "base16" Data.ByteString.Base16 as B16
 import "base16" Data.ByteString.Lazy.Base16 as B16L
 import "memory" Data.ByteArray.Encoding as Mem
@@ -30,7 +31,7 @@ tests = testGroup "Base16 Tests"
     [ testVectors
     , sanityTests
     , alphabetTests
-    , lenientTests
+ --   , lenientTests
     ]
 
 testVectors :: TestTree
@@ -164,6 +165,8 @@ alphabetTests = testGroup "Alphabet tests"
       , conformsL 4
       , conformsL 5
       , conformsL 6
+      , conformsL 32
+      , conformsL 33
       ]
     ]
   where
@@ -179,40 +182,40 @@ alphabetTests = testGroup "Alphabet tests"
       assertBool ("failed validity: " ++ show b) $ B16L.isValidBase16 b
       assertBool ("failed correctness: " ++ show b) $ B16L.isBase16 b
 
-lenientTests :: TestTree
-lenientTests = testGroup "Lenient Tests"
-    [ testGroup "strict encode/lenient decode"
-      [ testCaseB16 "" ""
-      , testCaseB16 "f" "6+6"
-      , testCaseB16 "fo" "6$6+6|f"
-      , testCaseB16 "foo" "==========6$$66()*f6f"
-      , testCaseB16 "foob" "66^%$&^6f6f62"
-      , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
-      , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
-      ]
-    , testGroup "lazy encode/decode"
-      [ testCaseB16 "" ""
-      , testCaseB16 "f" "6+++++++____++++++======*%$@#%#^*$^6"
-      , testCaseB16 "fo" "6$6+6|f"
-      , testCaseB16 "foo" "==========6$$66()*f6f"
-      , testCaseB16 "foob" "66^%$&^6f6f62"
-      , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
-      , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
-      ]
-    ]
-  where
-    testCaseB16 s t =
-      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
-        let t0 = B16.decodeBase16 (B16.encodeBase16' s)
-            t1 = B16.decodeBase16Lenient t
+-- lenientTests :: TestTree
+-- lenientTests = testGroup "Lenient Tests"
+--     [ testGroup "strict encode/lenient decode"
+--       [ testCaseB16 "" ""
+--       , testCaseB16 "f" "6+6"
+--       , testCaseB16 "fo" "6$6+6|f"
+--       , testCaseB16 "foo" "==========6$$66()*f6f"
+--       , testCaseB16 "foob" "66^%$&^6f6f62"
+--       , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+--       , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+--       ]
+--     , testGroup "lazy encode/decode"
+--       [ testCaseB16L "" ""
+--       , testCaseB16L "f" "6+++++++____++++++======*%$@#%#^*$^6"
+--       , testCaseB16L "fo" "6$6+6|f"
+--       , testCaseB16L "foo" "==========6$$66()*f6f"
+--       , testCaseB16L "foob" "66^%$&^6f6f62"
+--       , testCaseB16L "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+--       , testCaseB16L "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+--       ]
+--     ]
+--   where
+--     testCaseB16 s t =
+--       testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+--         let t0 = B16.decodeBase16 (B16.encodeBase16' s)
+--             t1 = B16.decodeBase16Lenient t
 
-        step "compare decoding"
-        t0 @=? Right t1
+--         step "compare decoding"
+--         t0 @=? Right t1
 
-    testCaseB16L s t =
-      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
-        let t0 = B16L.decodeBase16 (B16L.encodeBase16' s)
-            t1 = B16L.decodeBase16Lenient t
+--     testCaseB16L s t =
+--       testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+--         let t0 = fmap toStrict $ B16L.decodeBase16 (B16L.encodeBase16' s)
+--             t1 = Right . toStrict $ B16L.decodeBase16Lenient t
 
-        step "compare decoding"
-        t0 @=? Right t1
+--         step "compare decoding"
+--         t0 @=? t1

--- a/test/Base16Tests.hs
+++ b/test/Base16Tests.hs
@@ -30,6 +30,7 @@ tests = testGroup "Base16 Tests"
     [ testVectors
     , sanityTests
     , alphabetTests
+    , lenientTests
     ]
 
 testVectors :: TestTree
@@ -177,3 +178,41 @@ alphabetTests = testGroup "Alphabet tests"
       let b = B16L.encodeBase16' bs
       assertBool ("failed validity: " ++ show b) $ B16L.isValidBase16 b
       assertBool ("failed correctness: " ++ show b) $ B16L.isBase16 b
+
+lenientTests :: TestTree
+lenientTests = testGroup "Lenient Tests"
+    [ testGroup "strict encode/lenient decode"
+      [ testCaseB16 "" ""
+      , testCaseB16 "f" "6+6"
+      , testCaseB16 "fo" "6$6+6|f"
+      , testCaseB16 "foo" "==========6$$66()*f6f"
+      , testCaseB16 "foob" "66^%$&^6f6f62"
+      , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+      , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+      ]
+    , testGroup "lazy encode/decode"
+      [ testCaseB16 "" ""
+      , testCaseB16 "f" "6+++++++____++++++======*%$@#%#^*$^6"
+      , testCaseB16 "fo" "6$6+6|f"
+      , testCaseB16 "foo" "==========6$$66()*f6f"
+      , testCaseB16 "foob" "66^%$&^6f6f62"
+      , testCaseB16 "fooba" "666f()*#@6f#)(@*)6()*)2()61"
+      , testCaseB16 "foobar" "6@6@6@f@6@f@6@2@6@1@7@2++++++++++++++++++++++++"
+      ]
+    ]
+  where
+    testCaseB16 s t =
+      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+        let t0 = B16.decodeBase16 (B16.encodeBase16' s)
+            t1 = B16.decodeBase16Lenient t
+
+        step "compare decoding"
+        t0 @=? Right t1
+
+    testCaseB16L s t =
+      testCaseSteps (show $ if s == "" then "empty" else s) $ \step -> do
+        let t0 = B16L.decodeBase16 (B16L.encodeBase16' s)
+            t1 = B16L.decodeBase16Lenient t
+
+        step "compare decoding"
+        t0 @=? Right t1


### PR DESCRIPTION
Adds lenient decoding functions to the bytestring and text modules. Additionally, this PR proposes two additions to the spec when dealing with `Text` values: 

1. All `Text` values are now decoded as `latin1` by default, because, as HVR explained, `decodeLatin1` is the only total function for decoding unicode values. Barring a more typesafe design with smart constructors distinguishing hexadecimal text from your average text values, this seems like the safest bet. `decodeBase16 . encodeBase16` is always coherent under these conditions, and the extension to the decoder is only there to accommodate garbage values people throw at it. It will always successfully decode them, but in the end, the user is left with garbage. Garbage in, garbage out!

2. I'm proposing a `decodeBase16With` function which takes a function `ByteString -> Either err Text` and produces `Either (Base16Error err) Text`. This `Base16Error` type consists of two cases: a case denoting standard errors returned in the `Left` case of `decodeBase16` called `DecodeError`, and an error type `ConversionError`, which is the type of error raised by the user as a result of converting `ByteString -> Text`. Thus, we have: 

```haskell
data Base16Error e
  = DecodeError Text
    -- ^ The error associated with decoding failure
    -- as a result of the Base16 decoding process
  | ConversionError e
    -- ^ The error associated with the decoding failure
    -- as a result of the conversion process `'ByteString' -> 'Text'
  deriving (Eq, Show)

decodeBase16With
    :: (ByteString -> Either err Text)
    -> Text
    -> Either (Base16Error err) Text
decodeBase16With f t = case B16.decodeBase16 $ T.encodeUtf8 t of
  Left de -> Left $ DecodeError de
  Right a -> first ConversionError (f a)
```