### PR TITLE
Remove useless lazy pattern

### DIFF
--- a/src/Data/ByteString/Base16/Internal/Utils.hs
+++ b/src/Data/ByteString/Base16/Internal/Utils.hs
@@ -41,7 +41,7 @@ reChunk (c:cs) = case B.length c `divMod` 2 of
   where
     cont_ q [] = [q]
     cont_ q (a:as) = case B.splitAt 1 a of
-      ~(x, y) -> let q' = B.append q x
+      (x, y) -> let q' = B.append q x
         in if B.length q' == 2
           then
             let as' = if B.null y then as else y:as


### PR DESCRIPTION
The `cont_` local function had a lazy pattern match that didn't do anything, because the result is used strictly. Remove it.