### PR TITLE
Allow text-2.0 in version bounds

### DIFF
--- a/base16.cabal
+++ b/base16.cabal
@@ -49,7 +49,7 @@ library
     , bytestring  >=0.10 && <0.12
     , deepseq     ^>=1.4
     , primitive   >=0.6  && <0.8
-    , text        ^>=1.2
+    , text        ^>=1.2 || ^>= 2.0
     , text-short  ^>=0.1
 
   hs-source-dirs:   src


### PR DESCRIPTION
Update the package version bounds for the [`text`](https://hackage.haskell.org/package/text) package to support `text-2.0`. As far as I can tell there are no logic changes required to support the new major version, and `text-1` remains supported.

Related issue: https://github.com/emilypi/Base16/issues/19
